### PR TITLE
Introduce limited formatter customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This example uses the `set-properties` goal to set some maven properties from th
             <plugin>
                 <groupId>ca.szc.maven</groupId>
                 <artifactId>jsonpath-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.2.0</version>
                 <executions>
                     <execution>
                         <id>read-devdependencies</id>
@@ -51,7 +51,7 @@ This example uses the `modify` goal to change the version of a NPM `package.json
             <plugin>
                 <groupId>ca.szc.maven</groupId>
                 <artifactId>jsonpath-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.2.0</version>
                 <executions>
                     <execution>
                         <id>update-version</id>
@@ -61,6 +61,7 @@ This example uses the `modify` goal to change the version of a NPM `package.json
                         </goals>
                         <configuration>
                             <file>${project.build.directory}/package.json</file>
+                            <formatter>conventional</formatter>
                             <modifications>
                                 <modification>
                                     <expression>$.version</expression>
@@ -77,6 +78,10 @@ This example uses the `modify` goal to change the version of a NPM `package.json
 ```
 
 ## Changelog
+
+### 1.2.0
+
+Change default pretty printer for `modify` goal, such that it returns output that is more conventional. Specify `<formatter>jackson</formatter>` for jackson's default formatter.
 
 ### 1.1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>ca.szc.maven</groupId>
     <artifactId>jsonpath-maven-plugin</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.10.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/src/main/java/ca/szc/maven/jsonpath/ConventionalPrettyPrinter.java
+++ b/src/main/java/ca/szc/maven/jsonpath/ConventionalPrettyPrinter.java
@@ -1,0 +1,32 @@
+package ca.szc.maven.jsonpath;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.util.Separators;
+
+public class ConventionalPrettyPrinter extends DefaultPrettyPrinter
+{
+    private static final long serialVersionUID = 1;
+
+    public ConventionalPrettyPrinter() {
+        super();
+        this._arrayIndenter = this._objectIndenter;
+    }
+
+    @Override
+    public ConventionalPrettyPrinter withSeparators(Separators separators)
+    {
+        this._separators = separators;
+        _objectFieldValueSeparatorWithSpaces = separators.getObjectFieldValueSeparator() + " ";
+        return this;
+    }
+
+    @Override
+    public ConventionalPrettyPrinter createInstance()
+    {
+        return new ConventionalPrettyPrinter();
+    }
+}


### PR DESCRIPTION
The default jackson formatter produces stange looking output. A custom
`PrettyPrinter` (`ConventionalPrettyPrinter`) results in output more typical
for standard tools like jq and npm.

`ConventionalPrettyPrinter` is made the default for `ModifyMojo`. The new
parameter `formatter` allows the user to go back to the jackson formatter if
they want.

Also update the README and bump the version to 1.2.0

Addresses #5 